### PR TITLE
feat: language-store

### DIFF
--- a/src/lib/stores/language.test.ts
+++ b/src/lib/stores/language.test.ts
@@ -1,0 +1,23 @@
+import { get } from 'svelte/store';
+import { lang, toggleLang } from './language';
+
+describe('language store', () => {
+  beforeEach(() => {
+    lang.set('ko');
+  });
+
+  it('기본값은 ko', () => {
+    expect(get(lang)).toBe('ko');
+  });
+
+  it('toggleLang: ko → en', () => {
+    toggleLang();
+    expect(get(lang)).toBe('en');
+  });
+
+  it('toggleLang: en → ko', () => {
+    lang.set('en');
+    toggleLang();
+    expect(get(lang)).toBe('ko');
+  });
+});

--- a/src/lib/stores/language.ts
+++ b/src/lib/stores/language.ts
@@ -1,0 +1,8 @@
+import { writable } from 'svelte/store';
+
+export type Lang = 'ko' | 'en';
+export const lang = writable<Lang>('ko');
+
+export function toggleLang(): void {
+	lang.update((l) => (l === 'ko' ? 'en' : 'ko'));
+}


### PR DESCRIPTION
## Summary
- `src/lib/stores/language.ts` — `lang` writable store (기본값 `'ko'`) + `toggleLang()` 토글 함수
- `src/lib/stores/language.test.ts` — 기본값, ko→en, en→ko 3개 테스트 (TDD)

## Test plan
- [x] `npm run test` — 3 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)