### PR TITLE
feat: parsemarkdown-migration

### DIFF
--- a/src/lib/mdfiles/BIOMASSPROJECT.md
+++ b/src/lib/mdfiles/BIOMASSPROJECT.md
@@ -1,7 +1,13 @@
 ---
-title: Cloud-based DevOps Environment Setup for Biomass Power Plant Operations
-Project Duration:  2023.06 ~ 
-Project Overview: Integration of existing and new sensor operational data from Biomass power plants into an AWS Cloud environment with DevOps and CI/CD capabilities
-Applied Technologies: AWS CDK, Python, Lambda, S3, Airflow, QuickSight
-Key Roles: DevOps Environment Developer, Data Visualization Developer
+title_ko: 바이오매스 발전소 클라우드 DevOps 환경 구축
+title_en: Cloud-based DevOps Environment for Biomass Power Plant
+type: work
+duration: 2023.06 ~
+overview_ko: 바이오매스 발전소 센서 데이터를 AWS 클라우드로 통합하고 DevOps/CI-CD 환경 구축
+overview_en: Integrated biomass power plant sensor data into AWS Cloud with DevOps and CI/CD capabilities
+role_ko: DevOps 환경 개발자 · 데이터 시각화 개발자
+role_en: DevOps Environment Developer · Data Visualization Developer
+tech: AWS CDK, Python, Lambda, S3, Airflow, QuickSight
+thumbnail: ""
+screenshots: []
 ---

--- a/src/lib/mdfiles/DOCUMENTPROJECT.md
+++ b/src/lib/mdfiles/DOCUMENTPROJECT.md
@@ -1,7 +1,13 @@
 ---
-title: In-house Technical Document System UI/UX Improvement Project
-Project Duration: 2024.06 ~ 
-Project Overview: Improving the existing in-house technical document system by building an AWS cloud-based environment and enhancing search capabilities
-Applied Technologies: AWS CDK, Lambda, DynamoDB, S3, API Gateway, CloudFront, SvelteKit
-Key Roles: AWS CDK-based Full Stack Developer
+title_ko: 사내 기술 문서 시스템 UI/UX 개선 프로젝트
+title_en: In-house Technical Document System UI/UX Improvement
+type: work
+duration: 2024.06 ~
+overview_ko: 기존 사내 기술 문서 시스템을 AWS 클라우드 기반으로 재구축하고 검색 기능 강화
+overview_en: Rebuilt internal technical document system on AWS cloud with enhanced search capabilities
+role_ko: AWS CDK 기반 풀스택 개발자
+role_en: AWS CDK-based Full Stack Developer
+tech: AWS CDK, Lambda, DynamoDB, S3, API Gateway, CloudFront, SvelteKit
+thumbnail: ""
+screenshots: []
 ---

--- a/src/lib/mdfiles/INSPECTION.md
+++ b/src/lib/mdfiles/INSPECTION.md
@@ -1,7 +1,13 @@
 ---
-title: Equipment Inspection Process Improve Project
-Project Duration: 2022.03 ~ 2022.06
-Project Overview: Digitalization of paper-based equipment inspection process in power plants
-Applied Technologies: JavaScript, HTML, CSS, Vue, Vuetify, Python, Django DRF, Pandas
-Key Roles: Full Stack
+title_ko: 설비 점검 프로세스 개선 프로젝트
+title_en: Equipment Inspection Process Improvement Project
+type: work
+duration: 2022.03 ~ 2022.06
+overview_ko: 발전소의 종이 기반 설비 점검 프로세스를 디지털화하여 업무 효율 향상
+overview_en: Digitalized paper-based equipment inspection process in power plants
+role_ko: 풀스택 개발자
+role_en: Full Stack Developer
+tech: JavaScript, HTML, CSS, Vue, Vuetify, Python, Django DRF, Pandas
+thumbnail: ""
+screenshots: []
 ---

--- a/src/lib/mdfiles/KEYNEWSPROJECT.md
+++ b/src/lib/mdfiles/KEYNEWSPROJECT.md
@@ -1,7 +1,13 @@
 ---
-title: Key News Improvement Project 
-Project Duration: 2022.06 ~ 2022.09
-Project Overview: Project to easily find and share key news related to internal business
-Applied Technologies: JavaScript, HTML, CSS, Vue, Vuetify, Python, Django DRF
-Key Roles: Related internal business News find Module Development(Use cosine similarity)
+title_ko: 핵심 뉴스 개선 프로젝트
+title_en: Key News Improvement Project
+type: work
+duration: 2022.06 ~ 2022.09
+overview_ko: 코사인 유사도 기반 뉴스 추천으로 사내 핵심 뉴스 탐색 및 공유 개선
+overview_en: Improved internal news discovery and sharing via cosine similarity-based recommendation
+role_ko: 뉴스 추천 모듈 개발자
+role_en: News Recommendation Module Developer
+tech: JavaScript, HTML, CSS, Vue, Vuetify, Python, Django DRF, Pandas, gensim, nltk, konlpy
+thumbnail: ""
+screenshots: []
 ---

--- a/src/lib/mdfiles/MAXPOWEPROJECT.md
+++ b/src/lib/mdfiles/MAXPOWEPROJECT.md
@@ -1,7 +1,13 @@
 ---
-title: Power Plant Maximum Output Prediction Project
-Project Duration: 2021.03 ~ 2021.06
-Project Overview: Development of a site to predict maximum output for improving bidding process in combined cycle power plants
-Applied Technologies: JavaScript, HTML, CSS, Python, Django, Pandas, XGBoost
-Key Roles: Front-end Developer, AI Model Developer
+title_ko: 발전소 최대 출력 예측 프로젝트
+title_en: Power Plant Maximum Output Prediction Project
+type: work
+duration: 2021.03 ~ 2021.06
+overview_ko: XGBoost 기반 AI 모델로 복합화력발전소 최대 출력을 예측하여 입찰 프로세스 개선
+overview_en: Improved bidding process by predicting max output of combined cycle power plant via XGBoost
+role_ko: FE 개발자 · AI 모델 개발자
+role_en: Front-end Developer · AI Model Developer
+tech: JavaScript, HTML, CSS, Python, Django, Pandas, XGBoost
+thumbnail: ""
+screenshots: []
 ---

--- a/src/lib/mdfiles/RPAPROJECT.md
+++ b/src/lib/mdfiles/RPAPROJECT.md
@@ -1,7 +1,13 @@
 ---
-title: Automated Expense Management Web Application
-Project Duration: 2022.01 ~ 2022.03
-Project Overview: Corporate Recurring Payment Task RPA Improvement Project
-Applied Technologies: HTML/CSS,JS,Python,Vue,Docker
-Key Roles: Front-end Developer, Selenium RPA Module Developer
+title_ko: 경비 처리 자동화 웹 애플리케이션
+title_en: Automated Expense Management Web Application
+type: work
+duration: 2022.01 ~ 2022.03
+overview_ko: 반복적인 법인카드 경비 처리 업무를 Selenium RPA로 자동화하여 월 40시간 절감
+overview_en: Automated corporate card expense workflows via Selenium RPA, saving 40 hrs/month
+role_ko: FE 개발자 · Selenium RPA 모듈 개발
+role_en: Front-end Developer · Selenium RPA Module Developer
+tech: HTML/CSS, JavaScript, Python, Vue, Docker, Selenium
+thumbnail: ""
+screenshots: []
 ---

--- a/src/lib/parseMarkdown.test.ts
+++ b/src/lib/parseMarkdown.test.ts
@@ -1,0 +1,45 @@
+import { parseMarkdown, markdownToHtml } from './parseMarkdown';
+
+const SAMPLE_MD = `---
+title_ko: 테스트 프로젝트
+title_en: Test Project
+type: work
+duration: 2022.01 ~ 2022.03
+overview_ko: 테스트 개요
+overview_en: Test overview
+role_ko: FE 개발자
+role_en: FE Developer
+tech: Python, Vue, Docker
+thumbnail: /images/test-thumb.png
+screenshots: ["/images/test-1.png", "/images/test-2.png"]
+---
+본문 내용`;
+
+describe('parseMarkdown', () => {
+  it('새 frontmatter 필드를 파싱한다', () => {
+    const { metadata } = parseMarkdown(SAMPLE_MD);
+    expect(metadata.title_ko).toBe('테스트 프로젝트');
+    expect(metadata.title_en).toBe('Test Project');
+    expect(metadata.type).toBe('work');
+    expect(metadata.duration).toBe('2022.01 ~ 2022.03');
+    expect(metadata.overview_ko).toBe('테스트 개요');
+    expect(metadata.role_ko).toBe('FE 개발자');
+    expect(metadata.tech).toBe('Python, Vue, Docker');
+    expect(metadata.thumbnail).toBe('/images/test-thumb.png');
+  });
+
+  it('screenshots를 배열로 파싱한다', () => {
+    const { metadata } = parseMarkdown(SAMPLE_MD);
+    expect(metadata.screenshots).toEqual(['/images/test-1.png', '/images/test-2.png']);
+  });
+
+  it('본문 컨텐츠를 반환한다', () => {
+    const { content } = parseMarkdown(SAMPLE_MD);
+    expect(content.trim()).toBe('본문 내용');
+  });
+
+  it('markdownToHtml: 마크다운을 HTML로 변환한다', () => {
+    const html = markdownToHtml('**bold**');
+    expect(html).toContain('<strong>bold</strong>');
+  });
+});

--- a/src/lib/parseMarkdown.ts
+++ b/src/lib/parseMarkdown.ts
@@ -1,44 +1,64 @@
-// $lib/parseMarkdown.ts
 import { marked } from 'marked';
 
-export interface WorkMetadata {
-    title: string;
-    'Project Duration': string;
-    'Project Overview': string;
-    'Applied Technologies': string;
-    'Key Roles': string;
-    screenshots: string[];
+export interface ProjectMetadata {
+	title_ko: string;
+	title_en: string;
+	type: 'work' | 'side';
+	duration: string;
+	overview_ko: string;
+	overview_en: string;
+	role_ko: string;
+	role_en: string;
+	tech: string;
+	thumbnail: string;
+	screenshots: string[];
 }
 
-export function parseMarkdown(markdown: string): { metadata: WorkMetadata; content: string } {
-    const metadata: Partial<WorkMetadata> = {};
-    const contentLines = markdown.split('\n');
-    let content = '';
-    let inMetadata = false;
+export interface Project extends ProjectMetadata {
+	techList: string[];
+	content: string;
+}
 
-    for (const line of contentLines) {
-        if (line.trim() === '---') {
-            inMetadata = !inMetadata;
-            continue;
-        }
-        if (inMetadata) {
-            const [key, ...valueParts] = line.split(':').map(part => part.trim());
-            const value = valueParts.join(':').trim();
-            if (key && value) {
-                if (key === 'screenshots') {
-                    metadata[key] = JSON.parse(value);
-                } else {
-                    metadata[key as keyof WorkMetadata] = value;
-                }
-            }
-        } else {
-            content += line + '\n';
-        }
-    }
+export function parseMarkdown(markdown: string): {
+	metadata: ProjectMetadata;
+	content: string;
+} {
+	const metadata: Partial<ProjectMetadata> = {};
+	const lines = markdown.split('\n');
+	let content = '';
+	let inFrontmatter = false;
+	let frontmatterDone = false;
+	let dashCount = 0;
 
-    return { metadata: metadata as WorkMetadata, content };
+	for (const line of lines) {
+		if (line.trim() === '---' && dashCount < 2) {
+			dashCount++;
+			inFrontmatter = dashCount === 1;
+			if (dashCount === 2) {
+				inFrontmatter = false;
+				frontmatterDone = true;
+			}
+			continue;
+		}
+		if (inFrontmatter) {
+			const colonIdx = line.indexOf(':');
+			if (colonIdx === -1) continue;
+			const key = line.slice(0, colonIdx).trim();
+			const value = line.slice(colonIdx + 1).trim();
+			if (!key || !value) continue;
+			if (key === 'screenshots') {
+				(metadata as Record<string, unknown>)[key] = JSON.parse(value);
+			} else {
+				(metadata as Record<string, unknown>)[key] = value;
+			}
+		} else if (frontmatterDone) {
+			content += line + '\n';
+		}
+	}
+
+	return { metadata: metadata as ProjectMetadata, content };
 }
 
 export function markdownToHtml(markdown: string): string {
-    return marked(markdown);
+	return marked(markdown) as string;
 }


### PR DESCRIPTION
## Summary
- `parseMarkdown.ts` — `WorkMetadata` → `ProjectMetadata` (이중 언어 ko/en + type/thumbnail/tech 필드) + `Project` 인터페이스 추가
- `parseMarkdown.test.ts` — 4개 테스트 TDD (frontmatter 파싱, screenshots 배열, 본문, markdownToHtml)
- `src/lib/mdfiles/*.md` — 6개 파일 frontmatter 신규 포맷으로 마이그레이션 (thumbnail/screenshots는 이미지 추가 전까지 빈 값)

> `/Work` 페이지 타입 에러 32개는 Story 4에서 해결 예정 (구 `WorkMetadata` 참조)

## Test plan
- [x] `npm run test` — 7 tests passed (4 parseMarkdown + 3 language store)

🤖 Generated with [Claude Code](https://claude.com/claude-code)